### PR TITLE
 docs: Chainstack implementation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ape Chainstack Plugin
 
-Chainstack provider plugins for networks.
+Chainstack network provider plugins.
 
 This plugin allows using the Ape framework with Chainstack as a node provider in an easy and integrated way.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Python3 --version
 
 ### Virtual environment
 
-It is recommended to operate in a virtual environment; you will need to [install ApeWorX](https://github.com/ApeWorX/ape#installation) in the virtual environment if you decide to use one.
+It is recommended to operate in a virtual environment; you will need to [install Ape](https://github.com/ApeWorX/ape#installation) in the virtual environment if you decide to use one.
 
 Create a virtual environment.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Still, Ape focuses on a more modular approach, allowing us to build and use exte
   sudo apt-get install python3-dev
   ```
 
-> **Note:** Always check the [ApeWorX docs to find the updated requirements](https://docs.apeworx.io/ape/stable/userguides/quickstart.html#prerequisite).
+> **Note:** Always check the [Ape docs to find the updated requirements](https://docs.apeworx.io/ape/stable/userguides/quickstart.html#prerequisite).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin allows using the Ape framework with Chainstack as a node provider in
 
 ApeWorX is an innovative smart contract development and testing framework.
 It is inspired by Brownie, and it has essentially the same syntax.
-Still, ApeworX focuses on a more modular approach, allowing us to build and use external plugins to add functionality.
+Still, Ape focuses on a more modular approach, allowing us to build and use external plugins to add functionality.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This is a list and syntax of the networks available once you install the Chainst
 ':mainnet:geth', 'ethereum:mainnet:geth', ':mainnet:chainstack', 'ethereum:mainnet:chainstack', ':mainnet', 'ethereum:mainnet', ':ropsten:geth', 'ethereum:ropsten:geth', ':ropsten:chainstack', 'ethereum:ropsten:chainstack', ':ropsten', 'ethereum:ropsten', ':kovan:geth', 'ethereum:kovan:geth', ':kovan', 'ethereum:kovan', ':rinkeby:geth', 'ethereum:rinkeby:geth', ':rinkeby:chainstack', 'ethereum:rinkeby:chainstack', ':rinkeby', 'ethereum:rinkeby', ':goerli:geth', 'ethereum:goerli:geth', ':goerli:chainstack', 'ethereum:goerli:chainstack', ':goerli', 'ethereum:goerli', '::geth', 'ethereum:local:geth', '::test', 'ethereum:local:test', ':local', 'ethereum:local', 'ethereum'.
 ```
 
-Now you are ready to use ApeWorX to develop and test your smart contract, checkout the [Ape Academy](https://academy.apeworx.io/) for tutorials.
+Now you are ready to use Ape to develop and test your smart contract, checkout the [Ape Academy](https://academy.apeworx.io/) for tutorials.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,7 @@ Use the `--network` command to access the console using your node; for example:
 ape console --network ethereum:goerli:chainstack
 ```
 
-This is a list and syntax of the networks available once you install the Chainstack plugin.
-
-```bash
-':mainnet:geth', 'ethereum:mainnet:geth', ':mainnet:chainstack', 'ethereum:mainnet:chainstack', ':mainnet', 'ethereum:mainnet', ':ropsten:geth', 'ethereum:ropsten:geth', ':ropsten:chainstack', 'ethereum:ropsten:chainstack', ':ropsten', 'ethereum:ropsten', ':kovan:geth', 'ethereum:kovan:geth', ':kovan', 'ethereum:kovan', ':rinkeby:geth', 'ethereum:rinkeby:geth', ':rinkeby:chainstack', 'ethereum:rinkeby:chainstack', ':rinkeby', 'ethereum:rinkeby', ':goerli:geth', 'ethereum:goerli:geth', ':goerli:chainstack', 'ethereum:goerli:chainstack', ':goerli', 'ethereum:goerli', '::geth', 'ethereum:local:geth', '::test', 'ethereum:local:test', ':local', 'ethereum:local', 'ethereum'.
-```
+Check the Ape docs to see [how to select a network](https://docs.apeworx.io/ape/stable/userguides/networks.html).
 
 Now you are ready to use Ape to develop and test your smart contract, checkout the [Ape Academy](https://academy.apeworx.io/) for tutorials.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,73 @@
 # Ape Chainstack Plugin
 
-Chainstack Provider plugins for networks
+Chainstack provider plugins for networks.
 
-## Dependencies
+This plugin allows using the ApeWorX framework with Chainstack as a node provider in an easy and integrated way.
 
-* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
+ApeWorX is an innovative smart contract development and testing framework.
+It is inspired by Brownie, and it has essentially the same syntax.
+Still, ApeworX focuses on a more modular approach, allowing us to build and use external plugins to add functionality.
+
+## Table of contents
+
+- [Ape Chainstack Plugin](#ape-chainstack-plugin)
+  - [Requirements](#requirements)
+    - [Dependencies](#dependencies)
+  - [Installation](#installation)
+    - [Virtual environment](#virtual-environment)
+    - [Install ape-chainstack via `pip`](#install-ape-chainstack-via-pip)
+    - [Install ape-chainstack via `setuptools`](#install-ape-chainstack-via-setuptools)
+  - [Quick Usage](#quick-usage)
+  - [Development](#development)
+  - [License](#license)
+
+## Requirements
+
+- Linux or macOS
+- Windows Subsystem Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/install)) if operating on windows.
+
+### Dependencies
+
+- [python3](https://www.python.org/downloads) version 3.7.2 or greater
+- python3-dev
+
+  - MacOS. Should already have the [correct headers if Python is installed with `brew`](https://stackoverflow.com/questions/32578106/how-to-install-python-devel-in-mac-os)
+
+  - Linux. Install python3-dev with:
+
+  ```sh
+  sudo apt-get install python3-dev
+  ```
+
+> **Note:** Always check the [ApeWorX docs to find the updated requirements](https://docs.apeworx.io/ape/stable/userguides/quickstart.html#prerequisite).
 
 ## Installation
 
-### via `pip`
+Verify the Python version installed:
+
+```sh
+Python3 --version
+```
+
+### Virtual environment
+
+It is recommended to operate in a virtual environment; you will need to [install ApeWorX](https://github.com/ApeWorX/ape#installation) in the virtual environment if you decide to use one.
+
+Create a virtual environment.
+
+```sh
+python3 -m venv /path/to/new/environment
+```
+
+> Keep in mind that you can place the virtual environment where you prefer.
+
+Then activate it.
+
+```sh
+source /bin/activate
+```
+
+### Install ape-chainstack via `pip`
 
 You can install the latest release via [`pip`](https://pypi.org/project/pip/):
 
@@ -16,7 +75,7 @@ You can install the latest release via [`pip`](https://pypi.org/project/pip/):
 pip install ape-chainstack
 ```
 
-### via `setuptools`
+### Install ape-chainstack via `setuptools`
 
 You can clone the repository and use [`setuptools`](https://github.com/pypa/setuptools) for the most up-to-date version:
 
@@ -26,13 +85,71 @@ cd ape-chainstack
 python3 setup.py install
 ```
 
-## Quick Usage
-
-Use in most commands using the `--network` option:
+Verify that the Chainstack plugin was installed correctly with this command:
 
 ```bash
-ape console --network ethereum:ropsten:chainstack
+ape plugins list
 ```
+
+It will show a list of all the plugins installed, and Chainstack will be there.
+
+```bash
+Installed Plugins:
+  chainstack    0.1.0a2.dev7+gc039b8e.d20220727
+```
+
+## Quick Usage
+
+Follow these steps to sign up on Chainstack, deploy a node, and find your endpoint credentials:
+
+1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
+1. [Deploy a node](https://docs.chainstack.com/platform/join-a-public-network).
+1. [View node access and credentials](https://docs.chainstack.com/platform/view-node-access-and-credentials).
+
+> **Note:** At this moment only the Ethereum network is supported.
+
+Create an environment variable with your Chainstack node URL in this format `CHAINSTACK_"NETWORK"_URL=ENDPOINT_URL`; for example:
+
+```sh
+export CHAINSTACK_GOERLI_URL=https://nd-11X-26X-16X.p2pify.com/YOUR_API_KEY
+```
+
+Use the command `ape networks list` to see the networks available:
+
+```sh
+ethereum  (default)
+├── mainnet
+│   ├── geth  (default)
+│   └── chainstack
+├── ropsten
+│   ├── geth  (default)
+│   └── chainstack
+├── kovan
+│   └── geth  (default)
+├── rinkeby
+│   ├── geth  (default)
+│   └── chainstack
+├── goerli
+│   ├── geth  (default)
+│   └── chainstack
+└── local  (default)
+    ├── geth
+    └── test  (default)
+```
+
+Use the `--network` command to access the console using your node; for example:
+
+```bash
+ape console --network ethereum:goerli:chainstack
+```
+
+This is a list and syntax of the networks available once you install the Chainstack plugin.
+
+```bash
+':mainnet:geth', 'ethereum:mainnet:geth', ':mainnet:chainstack', 'ethereum:mainnet:chainstack', ':mainnet', 'ethereum:mainnet', ':ropsten:geth', 'ethereum:ropsten:geth', ':ropsten:chainstack', 'ethereum:ropsten:chainstack', ':ropsten', 'ethereum:ropsten', ':kovan:geth', 'ethereum:kovan:geth', ':kovan', 'ethereum:kovan', ':rinkeby:geth', 'ethereum:rinkeby:geth', ':rinkeby:chainstack', 'ethereum:rinkeby:chainstack', ':rinkeby', 'ethereum:rinkeby', ':goerli:geth', 'ethereum:goerli:geth', ':goerli:chainstack', 'ethereum:goerli:chainstack', ':goerli', 'ethereum:goerli', '::geth', 'ethereum:local:geth', '::test', 'ethereum:local:test', ':local', 'ethereum:local', 'ethereum'.
+```
+
+Now you are ready to use ApeWorX to develop and test your smart contract, checkout the [Ape Academy](https://academy.apeworx.io/) for tutorials.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chainstack provider plugins for networks.
 
 This plugin allows using the Ape framework with Chainstack as a node provider in an easy and integrated way.
 
-ApeWorX is an innovative smart contract development and testing framework.
+Ape is an innovative smart contract development and testing framework.
 It is inspired by Brownie, and it has essentially the same syntax.
 Still, Ape focuses on a more modular approach, allowing us to build and use external plugins to add functionality.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ It will show a list of all the plugins installed, and Chainstack will be there.
 
 ```bash
 Installed Plugins:
-  chainstack    0.1.0a2.dev7+gc039b8e.d20220727
+  chainstack    <current version number>
 ```
 
 ## Quick Usage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Chainstack provider plugins for networks.
 
-This plugin allows using the ApeWorX framework with Chainstack as a node provider in an easy and integrated way.
+This plugin allows using the Ape framework with Chainstack as a node provider in an easy and integrated way.
 
 ApeWorX is an innovative smart contract development and testing framework.
 It is inspired by Brownie, and it has essentially the same syntax.

--- a/ape_chainstack/providers.py
+++ b/ape_chainstack/providers.py
@@ -10,7 +10,6 @@ ETH_NETWORKS = [
     "mainnet",
     "ropsten",
     "rinkeby",
-    "kovan",
     "goerli",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     long_description_content_type="text/markdown",
     author="ApeWorX Ltd.",
     author_email="admin@apeworx.io",
-    url="https://github.com/ApeWorX/<REPO_NAME>",
+    url="https://github.com/ApeWorX/ape-chainstack",
     include_package_data=True,
     install_requires=[
         "eth-ape>=0.4.0,<0.5.0",


### PR DESCRIPTION
### What I did

- Updated repo URL in `setup.py` to https://github.com/ApeWorX/ape-chainstack
- Removed Kovan from `providers.py` as it's not supported by Chainstack
- Updated README.md

### Checklist

- [x ] Passes all linting checks (pre-commit and CI jobs)
- [ x] New test cases have been added and are passing
- [ x] Documentation has been updated
- [ x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
